### PR TITLE
Add ArtifactCheck plugin for Maven Central compliance

### DIFF
--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -32,5 +32,15 @@ gradlePlugin {
             id = "io.github.yonggoose.organization-defaults-setting"
             implementationClass = "io.github.yonggoose.organizationdefaults.OrganizationDefaultsSettingsPlugin"
         }
+
+        create("artifactCheckProject") {
+            id = "io.github.yonggoose.organization-defaults-artifact-check-project"
+            implementationClass = "io.github.yonggoose.organizationdefaults.ArtifactCheckPluginForProject"
+        }
+
+        create("artifactCheckSetting") {
+            id = "io.github.yonggoose.organization-defaults-artifact-check-setting"
+            implementationClass = "io.github.yonggoose.organizationdefaults.ArtifactCheckPluginForSetting"
+        }
     }
 }

--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -37,10 +37,5 @@ gradlePlugin {
             id = "io.github.yonggoose.organization-defaults-artifact-check-project"
             implementationClass = "io.github.yonggoose.organizationdefaults.ArtifactCheckPluginForProject"
         }
-
-        create("artifactCheckSetting") {
-            id = "io.github.yonggoose.organization-defaults-artifact-check-setting"
-            implementationClass = "io.github.yonggoose.organizationdefaults.ArtifactCheckPluginForSetting"
-        }
     }
 }

--- a/plugins/src/main/kotlin/io/github/yonggoose/organizationdefaults/ArtifactCheckPlugin.kt
+++ b/plugins/src/main/kotlin/io/github/yonggoose/organizationdefaults/ArtifactCheckPlugin.kt
@@ -2,7 +2,6 @@ package io.github.yonggoose.organizationdefaults
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.initialization.Settings
 
 class ArtifactCheckPluginForProject : Plugin<Project> {
     override fun apply(project: Project) {
@@ -12,100 +11,8 @@ class ArtifactCheckPluginForProject : Plugin<Project> {
                 "Verifies that all artifacts staged for publishing are signed according to Maven Central requirements."
 
             doLast {
-
-            }
-            val pom = project.rootProject.extensions.extraProperties.get("mergedDefaults") as? OrganizationDefaults
-                ?: throw IllegalStateException("mergedDefaults is not defined in the root project.")
-
-            val errors = mutableListOf<String>()
-
-            // GAV Coordinates validation
-            val groupId = pom.groupId
-            if (groupId == null || groupId.isBlank() || !groupId.matches(Regex("^[a-z]+(\\.[a-z][a-z0-9]*)+$"))) {
-                errors.add("Invalid groupId: Must be in reverse domain name format or not be null or blank.")
-            }
-
-            if (pom.artifactId.isNullOrBlank()) {
-                errors.add("Invalid artifactId: Must be a unique component name.")
-            }
-
-            val version = pom.version
-            if (version == null || (version.isBlank() || version.endsWith("-SNAPSHOT"))) {
-                errors.add("Invalid version: The version must not be null, blank, or end with '-SNAPSHOT'.")
-            }
-
-            // Project Information validation
-            if (pom.name.isNullOrBlank()) {
-                errors.add("Invalid name: Project name is required.")
-            }
-            if (pom.description.isNullOrBlank()) {
-                errors.add("Invalid description: Project description is required.")
-            }
-            if (pom.url.isNullOrBlank()) {
-                errors.add("Invalid url: Project URL is required.")
-            }
-
-            // License validation
-            pom.licenses.forEach { license ->
-                if (license.licenseType.isNullOrBlank()) {
-                    errors.add("Invalid license: License name is required.")
-                }
-            }
-
-            // Developer Info validation
-            pom.developers.forEach { developer ->
-                if (developer.name.isNullOrBlank()) {
-                    errors.add("Invalid developer: Developer name is required.")
-                }
-                if (developer.email.isNullOrBlank()) {
-                    errors.add("Invalid developer: Developer email is required.")
-                }
-                if (developer.organization.isNullOrBlank()) {
-                    errors.add("Invalid developer: Organization is required.")
-                }
-                if (developer.organizationUrl.isNullOrBlank()) {
-                    errors.add("Invalid developer: Organization URL is required.")
-                }
-            }
-
-            // SCM Information validation
-            pom.scm?.let { scm ->
-                if (scm.connection.isNullOrBlank()) {
-                    errors.add("Invalid SCM: Read-only connection is required.")
-                }
-                if (scm.developerConnection.isNullOrBlank()) {
-                    errors.add("Invalid SCM: Read/write connection is required.")
-                }
-                if (scm.url.isNullOrBlank()) {
-                    errors.add("Invalid SCM: Web interface URL is required.")
-                }
-            }
-
-            // Throw exception if there are errors
-            if (errors.isNotEmpty()) {
-                throw IllegalArgumentException("Validation failed:\n${errors.joinToString("\n")}")
-            }
-
-            project.logger.lifecycle("ArtifactCheckPlugin: All validations passed successfully.")
-        }
-    }
-}
-
-class ArtifactCheckPluginForSetting : Plugin<Settings> {
-    override fun apply(setting: Settings) {
-        setting.gradle.rootProject.tasks.register("checkSettingsArtifact") {
-            group = "Verification"
-            description =
-                "Verifies that all artifacts staged for publishing are signed according to Maven Central requirements."
-            doLast {
-                val rootProjectSetting = setting.gradle.sharedServices
-                    .registrations
-                    .named("rootProjectSetting")
-                    .get()
-                    .service
-                    .get() as OrganizationDefaultsService
-
-                val pom = rootProjectSetting.getDefaults()
+                val pom = project.rootProject.extensions.extraProperties.get("mergedDefaults") as? OrganizationDefaults
+                    ?: throw IllegalStateException("mergedDefaults is not defined in the root project.")
 
                 val errors = mutableListOf<String>()
 
@@ -120,7 +27,7 @@ class ArtifactCheckPluginForSetting : Plugin<Settings> {
                 }
 
                 val version = pom.version
-                if (version == null || version.isBlank() || version.endsWith("-SNAPSHOT")) {
+                if (version == null || (version.isBlank() || version.endsWith("-SNAPSHOT"))) {
                     errors.add("Invalid version: The version must not be null, blank, or end with '-SNAPSHOT'.")
                 }
 
@@ -176,7 +83,7 @@ class ArtifactCheckPluginForSetting : Plugin<Settings> {
                     throw IllegalArgumentException("Validation failed:\n${errors.joinToString("\n")}")
                 }
 
-                setting.gradle.rootProject.logger.lifecycle("ArtifactCheckPluginForSetting: All validations passed successfully.")
+                project.logger.lifecycle("ArtifactCheckPlugin: All validations passed successfully.")
             }
         }
     }

--- a/plugins/src/main/kotlin/io/github/yonggoose/organizationdefaults/ArtifactCheckPlugin.kt
+++ b/plugins/src/main/kotlin/io/github/yonggoose/organizationdefaults/ArtifactCheckPlugin.kt
@@ -1,0 +1,183 @@
+package io.github.yonggoose.organizationdefaults
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.initialization.Settings
+
+class ArtifactCheckPluginForProject : Plugin<Project> {
+    override fun apply(project: Project) {
+        project.tasks.register("checkProjectArtifact") {
+            group = "Verification"
+            description =
+                "Verifies that all artifacts staged for publishing are signed according to Maven Central requirements."
+
+            doLast {
+
+            }
+            val pom = project.rootProject.extensions.extraProperties.get("mergedDefaults") as? OrganizationDefaults
+                ?: throw IllegalStateException("mergedDefaults is not defined in the root project.")
+
+            val errors = mutableListOf<String>()
+
+            // GAV Coordinates validation
+            val groupId = pom.groupId
+            if (groupId == null || groupId.isBlank() || !groupId.matches(Regex("^[a-z]+(\\.[a-z][a-z0-9]*)+$"))) {
+                errors.add("Invalid groupId: Must be in reverse domain name format or not be null or blank.")
+            }
+
+            if (pom.artifactId.isNullOrBlank()) {
+                errors.add("Invalid artifactId: Must be a unique component name.")
+            }
+
+            val version = pom.version
+            if (version == null || (version.isBlank() || version.endsWith("-SNAPSHOT"))) {
+                errors.add("Invalid version: The version must not be null, blank, or end with '-SNAPSHOT'.")
+            }
+
+            // Project Information validation
+            if (pom.name.isNullOrBlank()) {
+                errors.add("Invalid name: Project name is required.")
+            }
+            if (pom.description.isNullOrBlank()) {
+                errors.add("Invalid description: Project description is required.")
+            }
+            if (pom.url.isNullOrBlank()) {
+                errors.add("Invalid url: Project URL is required.")
+            }
+
+            // License validation
+            pom.licenses.forEach { license ->
+                if (license.licenseType.isNullOrBlank()) {
+                    errors.add("Invalid license: License name is required.")
+                }
+            }
+
+            // Developer Info validation
+            pom.developers.forEach { developer ->
+                if (developer.name.isNullOrBlank()) {
+                    errors.add("Invalid developer: Developer name is required.")
+                }
+                if (developer.email.isNullOrBlank()) {
+                    errors.add("Invalid developer: Developer email is required.")
+                }
+                if (developer.organization.isNullOrBlank()) {
+                    errors.add("Invalid developer: Organization is required.")
+                }
+                if (developer.organizationUrl.isNullOrBlank()) {
+                    errors.add("Invalid developer: Organization URL is required.")
+                }
+            }
+
+            // SCM Information validation
+            pom.scm?.let { scm ->
+                if (scm.connection.isNullOrBlank()) {
+                    errors.add("Invalid SCM: Read-only connection is required.")
+                }
+                if (scm.developerConnection.isNullOrBlank()) {
+                    errors.add("Invalid SCM: Read/write connection is required.")
+                }
+                if (scm.url.isNullOrBlank()) {
+                    errors.add("Invalid SCM: Web interface URL is required.")
+                }
+            }
+
+            // Throw exception if there are errors
+            if (errors.isNotEmpty()) {
+                throw IllegalArgumentException("Validation failed:\n${errors.joinToString("\n")}")
+            }
+
+            project.logger.lifecycle("ArtifactCheckPlugin: All validations passed successfully.")
+        }
+    }
+}
+
+class ArtifactCheckPluginForSetting : Plugin<Settings> {
+    override fun apply(setting: Settings) {
+        setting.gradle.rootProject.tasks.register("checkSettingsArtifact") {
+            group = "Verification"
+            description =
+                "Verifies that all artifacts staged for publishing are signed according to Maven Central requirements."
+            doLast {
+                val rootProjectSetting = setting.gradle.sharedServices
+                    .registrations
+                    .named("rootProjectSetting")
+                    .get()
+                    .service
+                    .get() as OrganizationDefaultsService
+
+                val pom = rootProjectSetting.getDefaults()
+
+                val errors = mutableListOf<String>()
+
+                // GAV Coordinates validation
+                val groupId = pom.groupId
+                if (groupId == null || groupId.isBlank() || !groupId.matches(Regex("^[a-z]+(\\.[a-z][a-z0-9]*)+$"))) {
+                    errors.add("Invalid groupId: Must be in reverse domain name format or not be null or blank.")
+                }
+
+                if (pom.artifactId.isNullOrBlank()) {
+                    errors.add("Invalid artifactId: Must be a unique component name.")
+                }
+
+                val version = pom.version
+                if (version == null || version.isBlank() || version.endsWith("-SNAPSHOT")) {
+                    errors.add("Invalid version: The version must not be null, blank, or end with '-SNAPSHOT'.")
+                }
+
+                // Project Information validation
+                if (pom.name.isNullOrBlank()) {
+                    errors.add("Invalid name: Project name is required.")
+                }
+                if (pom.description.isNullOrBlank()) {
+                    errors.add("Invalid description: Project description is required.")
+                }
+                if (pom.url.isNullOrBlank()) {
+                    errors.add("Invalid url: Project URL is required.")
+                }
+
+                // License validation
+                pom.licenses.forEach { license ->
+                    if (license.licenseType.isNullOrBlank()) {
+                        errors.add("Invalid license: License name is required.")
+                    }
+                }
+
+                // Developer Info validation
+                pom.developers.forEach { developer ->
+                    if (developer.name.isNullOrBlank()) {
+                        errors.add("Invalid developer: Developer name is required.")
+                    }
+                    if (developer.email.isNullOrBlank()) {
+                        errors.add("Invalid developer: Developer email is required.")
+                    }
+                    if (developer.organization.isNullOrBlank()) {
+                        errors.add("Invalid developer: Organization is required.")
+                    }
+                    if (developer.organizationUrl.isNullOrBlank()) {
+                        errors.add("Invalid developer: Organization URL is required.")
+                    }
+                }
+
+                // SCM Information validation
+                pom.scm?.let { scm ->
+                    if (scm.connection.isNullOrBlank()) {
+                        errors.add("Invalid SCM: Read-only connection is required.")
+                    }
+                    if (scm.developerConnection.isNullOrBlank()) {
+                        errors.add("Invalid SCM: Read/write connection is required.")
+                    }
+                    if (scm.url.isNullOrBlank()) {
+                        errors.add("Invalid SCM: Web interface URL is required.")
+                    }
+                }
+
+                // Throw exception if there are errors
+                if (errors.isNotEmpty()) {
+                    throw IllegalArgumentException("Validation failed:\n${errors.joinToString("\n")}")
+                }
+
+                setting.gradle.rootProject.logger.lifecycle("ArtifactCheckPluginForSetting: All validations passed successfully.")
+            }
+        }
+    }
+}

--- a/testing/src/test/kotlin/unit/ArtifactCheckPluginTest.kt
+++ b/testing/src/test/kotlin/unit/ArtifactCheckPluginTest.kt
@@ -1,0 +1,119 @@
+package unit
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.testkit.runner.UnexpectedBuildFailure
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+class ArtifactCheckPluginTest {
+
+    @TempDir
+    lateinit var projectDir: Path
+
+    @Test
+    fun `checkProjectArtifact task should pass validation`() {
+        projectDir.resolve("build.gradle.kts").toFile().writeText(
+            """
+            plugins {
+                id("io.github.yonggoose.organization-defaults-artifact-check-project")
+                id("io.github.yonggoose.organization-defaults-project")
+            }
+            
+             rootProjectPom {
+                groupId = "io.github.yonggoose"
+                artifactId = "organization-defaults"
+                version = "1.0.0"
+                
+                name = "Test Organization"
+                description = "Organization defaults plugin test"
+                url = "https://example.org"
+                
+                licenses {
+                    license {
+                        licenseType = "MIT"
+                    }
+                    license {
+                        licenseType = "Apache-2.0"
+                    }
+                }
+                
+                developers {
+                    developer {
+                        id = "dev1"
+                        name = "Developer1"
+                        email = "dev1@example.com"
+                        timezone = "UTC"
+                        organization = "YongGoose"
+                        organizationUrl = "https://yonggoose.github.io"
+                    }
+                }
+                
+                scm {
+                    url = "https://github.com/YongGoose/organization-defaults"
+                    connection = "scm:git:git@github.com:YongGoose/organization-defaults.git"
+                    developerConnection = "scm:git:git@github.com:YongGoose/organization-defaults.git"
+                }
+            }
+            """.trimIndent()
+        )
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir.toFile())
+            .withArguments("checkProjectArtifact")
+            .withPluginClasspath()
+            .build()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":checkProjectArtifact")?.outcome)
+    }
+
+    @Test
+    fun `checkSettingsArtifact task should fail validation`() {
+        projectDir.resolve("build.gradle.kts").toFile().writeText(
+            """
+            plugins {
+                id("io.github.yonggoose.organization-defaults-artifact-check-project")
+                id("io.github.yonggoose.organization-defaults-project")
+            }
+            
+             rootProjectPom {
+                groupId = "io.github.yonggoose"
+                artifactId = "organization-defaults"
+                version = "1.0.0"
+                
+                
+                licenses {
+                    license {
+                        licenseType = "MIT"
+                    }
+                    license {
+                        licenseType = "Apache-2.0"
+                    }
+                }
+                
+                developers {
+                    developer {
+                        id = "dev1"
+                        name = "Developer1"
+                        email = "dev1@example.com"
+                        timezone = "UTC"
+                    }
+                }
+            }
+            """.trimIndent()
+        )
+
+        val exception = assertThrows<UnexpectedBuildFailure> {
+            GradleRunner.create()
+                .withProjectDir(projectDir.toFile())
+                .withArguments("checkProjectArtifact")
+                .withPluginClasspath()
+                .build()
+        }
+        assertTrue(exception.message?.contains("Validation failed") == true)
+    }
+}


### PR DESCRIPTION
- Implemented `checkProjectArtifact` task for project-level artifact validation
- Implemented `checkSettingsArtifact` task for settings-level artifact validation
- Added validation logic for GAV coordinates, project information, licenses, developers, and SCM details
- Throws exceptions for validation failures and logs success messages

### Ⅰ. Describe what this PR did
fix #22 